### PR TITLE
[0.2.x] Add global config opt

### DIFF
--- a/lib/monday/client.rb
+++ b/lib/monday/client.rb
@@ -11,7 +11,7 @@ require_relative "resources"
 require_relative "util"
 
 module Monday
-  # Client executes requests against the Monday.com API and
+  # Client executes requests against the monday.com's API and
   # allows a user to mutate and retrieve resources.
   class Client
     include Resources
@@ -19,18 +19,19 @@ module Monday
     JSON_CONTENT_TYPE = "application/json"
     private_constant :JSON_CONTENT_TYPE
 
-    Monday::Configuration::CONFIGURATION_FIELDS.each do |config_key|
-      define_method(config_key) do
-        @config.public_send(config_key)
-      end
-    end
+    attr_reader :config
 
     def initialize(config_args = {})
-      @config = Monday::Configuration.new(**config_args)
-      yield(@config) if block_given?
+      @config = config_options(config_args)
     end
 
     private
+
+    def config_options(config_args)
+      return Monday.config if config_args.empty?
+
+      Monday::Configuration.new(**config_args)
+    end
 
     def uri
       URI(@config.host)

--- a/lib/monday/configuration.rb
+++ b/lib/monday/configuration.rb
@@ -11,6 +11,9 @@ module Monday
     DEFAULT_HOST = "https://api.monday.com/v2"
     private_constant :DEFAULT_HOST
 
+    DEFAULT_TOKEN = nil
+    private_constant :DEFAULT_HOST
+
     CONFIGURATION_FIELDS = %i[
       token
       host
@@ -23,6 +26,7 @@ module Monday
       raise ArgumentError, "Unknown arguments: #{invalid_keys}" unless invalid_keys.empty?
 
       @host = DEFAULT_HOST
+      @token = DEFAULT_TOKEN
 
       config_args.each do |key, value|
         public_send("#{key}=", value)

--- a/lib/monday_ruby.rb
+++ b/lib/monday_ruby.rb
@@ -2,3 +2,16 @@
 
 require_relative "monday/client"
 require_relative "monday/version"
+
+# Module to configure the library globally
+module Monday
+  module_function
+
+  def configure
+    yield config
+  end
+
+  def config
+    @config ||= Configuration.new
+  end
+end

--- a/spec/monday/client_spec.rb
+++ b/spec/monday/client_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe Monday::Client do
     let(:config_args) { {} }
 
     it "creates an instance of Monday::Client with the default token" do
-      expect(client.token).to be nil
+      expect(client.config.token).to be nil
     end
 
     it "creates an instance of Monday::Client with the default host" do
-      expect(client.host).to eq(monday_url)
+      expect(client.config.host).to eq(monday_url)
     end
   end
 
@@ -25,11 +25,11 @@ RSpec.describe Monday::Client do
     let(:token) { "test_token" }
 
     it "creates an instance of Monday::Client with the provided token" do
-      expect(client.token).to eq(token)
+      expect(client.config.token).to eq(token)
     end
 
     it "creates an instance of Monday::Client with the default host" do
-      expect(client.host).to eq(monday_url)
+      expect(client.config.host).to eq(monday_url)
     end
   end
 


### PR DESCRIPTION
## Description

Add functionality to configure the library globally

Can configure using:

```ruby
Monday.configure do |config|
  config.token = "token"
end
```