### PR TITLE
fix: add base64 runtime dependency for Ruby 3.4 compatibility

### DIFF
--- a/monday_ruby.gemspec
+++ b/monday_ruby.gemspec
@@ -34,4 +34,6 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+
+  spec.add_runtime_dependency "base64"
 end


### PR DESCRIPTION
## Description

Add base64 runtime dependency for Ruby 3.4 compatibility