### PR TITLE
Added support for workspace folders: Query, Create, Update, Delete.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v1.1.0 (August 20, 2024)
+- Support for working with workspace folders:
+  - Query folders
+  - Create a folder
+  - Update a folder
+  - Delete a folder
+
 ## v1.0.0 (July 30, 2024)
 
 ### Changed

--- a/lib/monday/resources/folder.rb
+++ b/lib/monday/resources/folder.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+module Monday
+  module Resources
+    # Represents Monday.com's board resource.
+    class Folder < Base
+      DEFAULT_SELECT = %w[id name].freeze
+
+      # Retrieves all the folders.
+      #
+      # Allows filtering folders using the args option.
+      # Allows customizing the values to retrieve using the select option.
+      # By default, ID and name fields are retrieved.
+      def query(args: {}, select: DEFAULT_SELECT)
+        request_query = "query{folders#{Util.format_args(args)}{#{Util.format_select(select)}}}"
+
+        make_request(request_query)
+      end
+
+      # Create a new folder.
+      #
+      # Allows customizing creating a folder using the args option.
+      # Allows customizing the values to retrieve using the select option.
+      # By default, ID and name fields are retrieved.
+      def create(args: {}, select: DEFAULT_SELECT)
+        query = "mutation{create_folder#{Util.format_args(args)}{#{Util.format_select(select)}}}"
+
+        make_request(query)
+      end
+
+      # Update a folder.
+      #
+      # Allows customizing updating the folder using the args option.
+      # By default, returns the ID of the updated folder.
+      def update(args: {}, select: ["id"])
+        query = "mutation{update_folder#{Util.format_args(args)}{#{Util.format_select(select)}}}"
+
+        make_request(query)
+      end
+
+      # Delete a folder.
+      #
+      # Requires folder_id in args option to delete the folder.
+      # Allows customizing the values to retrieve using the select option.
+      # By default, returns the ID of the folder deleted.
+      def delete(args: {}, select: ["id"])
+        query = "mutation{delete_folder#{Util.format_args(args)}{#{Util.format_select(select)}}}"
+
+        make_request(query)
+      end
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_create/when_client_is_authenticated/when_a_field_that_doesn_t_exist_on_folders_is_given/raises_Monday_Error_error.yml
+++ b/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_create/when_client_is_authenticated/when_a_field_that_doesn_t_exist_on_folders_is_given/raises_Monday_Error_error.yml
@@ -1,0 +1,140 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"mutation{create_workspace(name: \"Test Workspace\", kind:
+        open){id name description}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Oct 2024 02:01:11 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Api-Version:
+      - 2024-10
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"0afbc6acd17df7a6ebf6abb29d097855"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 35a68f54-9157-9ea5-ac1a-ddea04016629
+      X-Runtime:
+      - '0.235398'
+      X-Envoy-Upstream-Service-Time:
+      - '238'
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=K1tRB_xidHeuQ6h0HzH4YnT7CJPP1SPlBfw3e8IBL68-1729476071-1.0.1.1-OLelTgP_kFCA7391vl4jnxp7DA3eA6hmlqTOOpUTlQENADzT6Y5RxnUIaLw0BElrJ4Kq8fjErAUO4Wdm9YOlEFB902anAzPniJ2_NjDWqp4;
+        path=/; expires=Mon, 21-Oct-24 02:31:11 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d5da8876dd508f2-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"create_workspace":{"id":"8529964","name":"Test Workspace","description":null}},"account_id":15314314}'
+  recorded_at: Mon, 21 Oct 2024 02:01:11 GMT
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"mutation{create_folder(workspace_id: \"8529964\", name: \"Database
+        boards\", invalid_field: \"test\"){id name}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Oct 2024 02:01:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Api-Version:
+      - 2024-10
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"765ea6a36319cb93e081062156e003b5"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 39c9aacd-19cd-9f73-9dc2-b66e9be160d1
+      X-Runtime:
+      - '0.059892'
+      X-Envoy-Upstream-Service-Time:
+      - '62'
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=Ho7l5XpiJtBY585yGBczQcR4eu4xKzIdk5.jaxN3lUY-1729476072-1.0.1.1-BB7_YO9Q80d.nEospaGWcyi6BgDv5X.dw8U2nWvg8tYIbeXswKP.FqGukkUjhVHJWqTJ9xji3ICME8R7GrTmCwWT9TkvxAeCi3eskp.A0ug;
+        path=/; expires=Mon, 21-Oct-24 02:31:12 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d5da88a5a317ed7-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"errors":[{"message":"Field ''create_folder'' doesn''t accept argument
+        ''invalid_field''","locations":[{"line":1,"column":74}],"path":["mutation","create_folder","invalid_field"],"extensions":{"code":"argumentNotAccepted","name":"create_folder","typeName":"Field","argumentName":"invalid_field"}}],"account_id":15314314}'
+  recorded_at: Mon, 21 Oct 2024 02:01:12 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_create/when_client_is_authenticated/when_args_are_valid/behaves_like_authenticated_client_request/returns_200_status.yml
+++ b/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_create/when_client_is_authenticated/when_args_are_valid/behaves_like_authenticated_client_request/returns_200_status.yml
@@ -1,0 +1,139 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"mutation{create_workspace(name: \"Test Workspace\", kind:
+        open){id name description}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Oct 2024 02:01:11 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Api-Version:
+      - 2024-10
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"3f0146ac8b6ff02d8f0a14b872f162b5"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 4525a4c1-88c3-9f04-9b0a-5bd020e4d9d9
+      X-Runtime:
+      - '0.234768'
+      X-Envoy-Upstream-Service-Time:
+      - '237'
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=DjFS7XHJVW7BlexlQn0zT5j.xKmaaWxnIHxki1agQWo-1729476071-1.0.1.1-2AiEcx2HiHx8I22OGa5.pSOM3MAuYph_m6tZ.fRqUq5cvrQ._ulC6NpuGwMg7PBjWxkEHbvG0qGjeDi3ervR.hT.78lOSFl4ENnN6JiK8_Q;
+        path=/; expires=Mon, 21-Oct-24 02:31:11 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d5da88209cd0ff4-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"create_workspace":{"id":"8529963","name":"Test Workspace","description":null}},"account_id":15314314}'
+  recorded_at: Mon, 21 Oct 2024 02:01:11 GMT
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"mutation{create_folder(workspace_id: \"8529963\", name: \"Database
+        boards\"){id name}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Oct 2024 02:01:11 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Api-Version:
+      - 2024-10
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"3430eec2d8ad7298b8a8a467b0d534b8"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - ec880b32-5c7f-9c15-9c6d-6d5c3c46a852
+      X-Runtime:
+      - '0.284087'
+      X-Envoy-Upstream-Service-Time:
+      - '287'
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=GIS4_YluU_jxocmJxw622wrObQdFWihhtDHfgrXp7kI-1729476071-1.0.1.1-zhFWIlq6Wc_KOlrdAwc9zcAoqq60frrP_REaKR6QsRLX.gSURNxJjBhYls4MIMK8kNRh1nLhsZUutetTKe6yM91ilt3m4048gOjyfKX5Pac;
+        path=/; expires=Mon, 21-Oct-24 02:31:11 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d5da8848a1169a6-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"create_folder":{"id":"15476756","name":"Database boards"}},"account_id":15314314}'
+  recorded_at: Mon, 21 Oct 2024 02:01:11 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_create/when_client_is_authenticated/when_args_are_valid/returns_the_body_with_created_folders_ID_and_Title.yml
+++ b/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_create/when_client_is_authenticated/when_args_are_valid/returns_the_body_with_created_folders_ID_and_Title.yml
@@ -1,0 +1,139 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"mutation{create_workspace(name: \"Test Workspace\", kind:
+        open){id name description}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Oct 2024 02:01:10 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Api-Version:
+      - 2024-10
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"083384c736cb2c265d2f175a3c8ec948"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 584bee3e-0607-981e-b4d3-299f187e0c80
+      X-Runtime:
+      - '0.327254'
+      X-Envoy-Upstream-Service-Time:
+      - '331'
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=9K7QZYrzsOwdx3lBmTL204VwPjrHun6J6Bc.xYJH9LM-1729476070-1.0.1.1-q2a3UKMyewo_eSwxSe.y.49zMAK7jw_FP9mV0q2674E7EWUj2Womrvoixz0M7VFNillnfmKOeqwjGDlz_h8mSWnpxa0UaxW.CBWFfrh6jvE;
+        path=/; expires=Mon, 21-Oct-24 02:31:10 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d5da87a1eb80cef-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"create_workspace":{"id":"8529962","name":"Test Workspace","description":null}},"account_id":15314314}'
+  recorded_at: Mon, 21 Oct 2024 02:01:10 GMT
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"mutation{create_folder(workspace_id: \"8529962\", name: \"Database
+        boards\"){id name}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Oct 2024 02:01:10 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Api-Version:
+      - 2024-10
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"791ad8d87fbf9d08cf263bfac6598d32"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - c877bb4c-ce45-9d59-887e-fbf8d5475e80
+      X-Runtime:
+      - '0.264756'
+      X-Envoy-Upstream-Service-Time:
+      - '268'
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=XIWRqgUAnQcXdscG6HYq27tSuF2bx6v5bppYv9dSgLY-1729476070-1.0.1.1-n5YPzBhQ0VYQlFLVAay_GqExthm4ZNx37YoIpb5Q.QZm5KkygCj_3EtxfuqyALwfHazXx5SKiL_pLY6McRbW7PXs.bdGFb4kj6hDOHHXXMw;
+        path=/; expires=Mon, 21-Oct-24 02:31:10 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d5da87eca892ea9-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"create_folder":{"id":"15476755","name":"Database boards"}},"account_id":15314314}'
+  recorded_at: Mon, 21 Oct 2024 02:01:10 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_create/when_client_is_not_authenticated/behaves_like_unauthenticated_client_request/raises_Monday_AuthorizationError_error.yml
+++ b/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_create/when_client_is_not_authenticated/behaves_like_unauthenticated_client_request/raises_Monday_AuthorizationError_error.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"mutation{create_folder{id name}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - invalid_token
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Date:
+      - Mon, 21 Oct 2024 02:01:09 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Powered-By:
+      - Express
+      X-Monday-Auth:
+      - 'true'
+      X-Monday-Region:
+      - undefined
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"20-1sxs6kzKvML1MCq/a35DgifHwjk"
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=FgHaqvcmUNjP5dmsXM.P3382FtYx.emDU17ajcK7y4k-1729476069-1.0.1.1-rLrgDXgQrtdXBM48lwigfUXwm9TJ1nTJvrUyvp2n9hSVhtIz_ZH7UhcaTGiKUjrfnmmbtKxqaQ3xe0xu6LMbipiklGDpO59D4HdNmAUlR80;
+        path=/; expires=Mon, 21-Oct-24 02:31:09 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d5da878dedd7e7d-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"errors":["Not Authenticated"]}'
+  recorded_at: Mon, 21 Oct 2024 02:01:09 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_delete/when_client_is_authenticated/when_a_the_folder_with_the_given_folder_ID_does_not_exist/raises_Monday_ResourceNotFoundError_error.yml
+++ b/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_delete/when_client_is_authenticated/when_a_the_folder_with_the_given_folder_ID_does_not_exist/raises_Monday_ResourceNotFoundError_error.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"mutation{delete_folder(folder_id: \"invalid_folder_name\"){id}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Oct 2024 02:01:09 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Api-Version:
+      - 2024-10
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"983a989bbfd86c0fb5ad6ca4c7384187"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 7fcc0bc9-b662-982a-a8c8-da83a77ab144
+      X-Runtime:
+      - '0.076583'
+      X-Envoy-Upstream-Service-Time:
+      - '81'
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=aYTa41EgWz7YXJTnDFyhP0CRCNLJWob6ng.h920zXGk-1729476069-1.0.1.1-x7KkmKTSg27dHhUWFlwtSd0uRP4oU46L_3zj2cEtu1v0URH_M83xtJ1VG2jSHToIhA_9npTP35fDnlA49pnPxW07RG3oTXkhV.o1sc0v7GA;
+        path=/; expires=Mon, 21-Oct-24 02:31:09 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d5da876493a7bf2-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"errors":[{"message":"The folder does not exist. Please check your
+        folder ID and try again","locations":[{"line":1,"column":10}],"path":["delete_folder"],"extensions":{"code":"InvalidFolderIdException","status_code":200,"error_data":{"folder_id":0}}}],"error_message":"The
+        folder does not exist. Please check your folder ID and try again","error_code":"InvalidFolderIdException","error_data":{"folder_id":0},"status_code":200,"account_id":15314314}'
+  recorded_at: Mon, 21 Oct 2024 02:01:08 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_delete/when_client_is_authenticated/when_the_args_are_valid/behaves_like_authenticated_client_request/returns_200_status.yml
+++ b/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_delete/when_client_is_authenticated/when_the_args_are_valid/behaves_like_authenticated_client_request/returns_200_status.yml
@@ -1,0 +1,206 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"mutation{create_workspace(name: \"Test Workspace\", kind:
+        open){id name description}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Oct 2024 02:01:07 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Api-Version:
+      - 2024-10
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"c25e4629230ccf18ac3b0c185cb21cde"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 62df62b4-4b38-9d78-97c2-380d1cad1234
+      X-Runtime:
+      - '0.255126'
+      X-Envoy-Upstream-Service-Time:
+      - '258'
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=3lSBmpmRPhv3auSzbYt.H7Ax5em59Ic29IWjWouUTHs-1729476067-1.0.1.1-nQOSqqZczM5fyp1lr9EAsZn1FEjkhCpI1wDdW14.PGAJrXpz1nn9lcrKOJ4.C2Ohi1ySru_Ss2u0m.V8D7ALUfMQw7JPXaEwtjRzjFbe36Y;
+        path=/; expires=Mon, 21-Oct-24 02:31:07 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d5da86d8f362ad7-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"create_workspace":{"id":"8529961","name":"Test Workspace","description":null}},"account_id":15314314}'
+  recorded_at: Mon, 21 Oct 2024 02:01:07 GMT
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"mutation{create_folder(workspace_id: \"8529961\", name: \"Database
+        boards\"){id name}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Oct 2024 02:01:08 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Api-Version:
+      - 2024-10
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"22a3f9a3beb3957912e15ed5f1161647"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 0b018ae9-872a-9dd8-960f-1f7094d39ed5
+      X-Runtime:
+      - '0.361727'
+      X-Envoy-Upstream-Service-Time:
+      - '370'
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=PElTxsugnGJcSfnbBut0OnVGZYoizKKDhiNahXs8QeE-1729476068-1.0.1.1-uz0tOnE0tRf2dLKRxLoGxqjdQw78xepASt9LMKO1.wB56gGid9GF0F.fXsVA5ZY7iwpjvEF_lClSS3n3uxS9hJ.K5Tl8SSaUxDl0EVdD0ws;
+        path=/; expires=Mon, 21-Oct-24 02:31:08 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d5da8701dbb0fd5-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"create_folder":{"id":"15476754","name":"Database boards"}},"account_id":15314314}'
+  recorded_at: Mon, 21 Oct 2024 02:01:08 GMT
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"mutation{delete_folder(folder_id: \"15476754\"){id}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Oct 2024 02:01:08 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Api-Version:
+      - 2024-10
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"2d8cf67dfa2ae6ff584609a5b896c5a8"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 492accc9-0377-9a63-a0a6-34568398952f
+      X-Runtime:
+      - '0.215314'
+      X-Envoy-Upstream-Service-Time:
+      - '218'
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=S3PkLjX3jMlxz7H1WwmuNfkrq2oYiunGpuPZYHZZwWI-1729476068-1.0.1.1-IdeLefzTSVpgVFGbsJIdRuM8zdTqM9TKC1THmv9Pc0S3ksYv7F.ShnhuoaFCe3xJKKrATSqsArVvoZn_ojddxb_iE2QrZQ7efbCAibHrFz0;
+        path=/; expires=Mon, 21-Oct-24 02:31:08 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d5da873eb4b0fcf-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"delete_folder":{"id":"15476754"}},"account_id":15314314}'
+  recorded_at: Mon, 21 Oct 2024 02:01:08 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_delete/when_client_is_authenticated/when_the_args_are_valid/returns_the_body_with_deleted_folders_ID.yml
+++ b/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_delete/when_client_is_authenticated/when_the_args_are_valid/returns_the_body_with_deleted_folders_ID.yml
@@ -1,0 +1,206 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"mutation{create_workspace(name: \"Test Workspace\", kind:
+        open){id name description}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Oct 2024 02:01:06 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Api-Version:
+      - 2024-10
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"efc4cd98fd14e77fcc9546b87beb8239"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - ad04303e-106a-9dec-a148-09b45bb8df49
+      X-Runtime:
+      - '0.285411'
+      X-Envoy-Upstream-Service-Time:
+      - '288'
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=cVUtDbwETimTB2E1XXD2wY8whetVhkOH1Bsi2mI4Ins-1729476066-1.0.1.1-nzNwwtdkMNfFq4QpaO81n1OyJaJ4_LvbOczPDGzqWYpfzb_ReRLdB98wrUNhDTaZrz5oPEpZL5SAIuIG2fEeUdOyhmmVOYQ6v4BLGdgoQCc;
+        path=/; expires=Mon, 21-Oct-24 02:31:06 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d5da861bea414ea-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"create_workspace":{"id":"8529960","name":"Test Workspace","description":null}},"account_id":15314314}'
+  recorded_at: Mon, 21 Oct 2024 02:01:06 GMT
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"mutation{create_folder(workspace_id: \"8529960\", name: \"Database
+        boards\"){id name}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Oct 2024 02:01:06 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Api-Version:
+      - 2024-10
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"f6b02db633968a8cde7109e23df1061a"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 0f191a6f-e40f-9d2c-a3c2-55e06f2b2d19
+      X-Runtime:
+      - '0.349543'
+      X-Envoy-Upstream-Service-Time:
+      - '352'
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=QbFtBFEVgUTDvfxVVZMhJAwL8DwvSWngEbscU5o9HCI-1729476066-1.0.1.1-.LDVRE4OedOdntFF9M9cIalH6pl00IkzaMmo8WBUMo732SXa.eshnbDz2wTskbNy1dxDTZwFJ8kD3kH2.n4Bok0bIuuiiipxCrMroN8DW0I;
+        path=/; expires=Mon, 21-Oct-24 02:31:06 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d5da865d92f100b-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"create_folder":{"id":"15476753","name":"Database boards"}},"account_id":15314314}'
+  recorded_at: Mon, 21 Oct 2024 02:01:06 GMT
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"mutation{delete_folder(folder_id: \"15476753\"){id}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Oct 2024 02:01:07 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Api-Version:
+      - 2024-10
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"35ab917484dfac09f65409357242fb73"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 23b0267a-8a85-9252-bbe3-42f87036f0fd
+      X-Runtime:
+      - '0.253343'
+      X-Envoy-Upstream-Service-Time:
+      - '271'
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=0CJU.f2QI2PDjrgR..EPzENRu171q_CwET_wDQGU5ZY-1729476067-1.0.1.1-WN0X3kV4pcztVOzB9RxeU1vjv2CNISu_1iCx5HoBVFfVxVnXmHuTrlEWmcwUqITAXvar4S9J1sUcDQ.v.KSRc0SaDOTEABYxka7ljNZmu.0;
+        path=/; expires=Mon, 21-Oct-24 02:31:07 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d5da8692e707bb6-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"delete_folder":{"id":"15476753"}},"account_id":15314314}'
+  recorded_at: Mon, 21 Oct 2024 02:01:07 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_delete/when_client_is_not_authenticated/behaves_like_unauthenticated_client_request/raises_Monday_AuthorizationError_error.yml
+++ b/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_delete/when_client_is_not_authenticated/behaves_like_unauthenticated_client_request/raises_Monday_AuthorizationError_error.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"mutation{delete_folder(folder_id: \"123\"){id}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - invalid_token
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Date:
+      - Mon, 21 Oct 2024 02:01:09 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      Vary:
+      - Origin, Accept-Encoding
+      X-Monday-Auth:
+      - 'true'
+      X-Powered-By:
+      - Express
+      X-Monday-Region:
+      - undefined
+      Etag:
+      - W/"20-1sxs6kzKvML1MCq/a35DgifHwjk"
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=GI8hNqpGuVv7HpAd7VUa60GMW_oWG4p6ijL94OVwTIA-1729476069-1.0.1.1-Ew5mBHBEIZaQIRYZwvzsO1gKE2gwEWFVqgc_RrzRzpJPUtJFa_hgDWKrLukKR4BLJgtanCn7NDPI0_kwdBt3vPNZsy7Df6k3U5KUA99WJGk;
+        path=/; expires=Mon, 21-Oct-24 02:31:09 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d5da877dc457eb7-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"errors":["Not Authenticated"]}'
+  recorded_at: Mon, 21 Oct 2024 02:01:09 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_query/when_client_is_authenticated/when_an_invalid_field_is_requested/raises_Monday_Error_error.yml
+++ b/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_query/when_client_is_authenticated/when_an_invalid_field_is_requested/raises_Monday_Error_error.yml
@@ -1,0 +1,71 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"query{folders{invalid_field}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Oct 2024 02:00:58 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Api-Version:
+      - 2024-10
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"850bd018e193c851e2c4c962b023061e"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - d2b69632-95b5-99e5-a2c8-c99ad5acd62e
+      X-Runtime:
+      - '0.079790'
+      X-Envoy-Upstream-Service-Time:
+      - '84'
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=_gjXCQQE72CMCkkTD.QIn6ijNdPJ2nBVVoh36TjlgtY-1729476058-1.0.1.1-1p1wwQp1vC3D5NVpcmOYVGtv1_grQufVZQpJ57_TiWteoqvwcyVy8_oCLaKM0auHy6qPVXM7mmk_TQ0mZqQEtcDAxoaKZ4jEgj.WhBk4aCs;
+        path=/; expires=Mon, 21-Oct-24 02:30:58 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d5da83709f4cb96-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"errors":[{"message":"Field ''invalid_field'' doesn''t exist on type
+        ''Folder''","locations":[{"line":1,"column":15}],"path":["query","folders","invalid_field"],"extensions":{"code":"undefinedField","typeName":"Folder","fieldName":"invalid_field"}}],"account_id":15314314}'
+  recorded_at: Mon, 21 Oct 2024 02:00:58 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_query/when_client_is_authenticated/when_valid_fields_are_requested/behaves_like_authenticated_client_request/returns_200_status.yml
+++ b/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_query/when_client_is_authenticated/when_valid_fields_are_requested/behaves_like_authenticated_client_request/returns_200_status.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"query{folders{id name}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Oct 2024 02:00:59 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Api-Version:
+      - 2024-10
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"c407e74c1a39eba6cd0242f963afb49f"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 20bffc76-9d01-96ae-8a08-8cd57c7579af
+      X-Runtime:
+      - '0.081282'
+      X-Envoy-Upstream-Service-Time:
+      - '85'
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=lTtWjgt94zUx.3ZsVn3lFLqcv6Sc2BTw.k_0PS_FEqU-1729476059-1.0.1.1-jwAnzYqWoqiZF6G1MiWKvM97SmEe6Vj19y_4H1FTbsCZbYhKTIwIQq.nurXE9tMhH.yl4Lee8LBzF2RY9D.tRtg20ikwh78FhhZbArzPpFY;
+        path=/; expires=Mon, 21-Oct-24 02:30:59 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d5da83b8b980905-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"folders":[{"id":"10918734","name":"LE Development Team"},{"id":"10977318","name":"CRM"},{"id":"11061563","name":"LB"},{"id":"12772091","name":"Projects"},{"id":"12774555","name":"Meetings"},{"id":"13019652","name":"1836"},{"id":"13145433","name":"Database"},{"id":"13145448","name":"Workspace"},{"id":"13155563","name":"Job
+        Flow"},{"id":"13156741","name":"Reporting"},{"id":"13156743","name":"Other"},{"id":"13157369","name":"Reports"},{"id":"13177585","name":"Rentvine"},{"id":"13190752","name":"RentVine
+        Sync"},{"id":"13201660","name":"Documentation"},{"id":"13214161","name":"Sandbox"},{"id":"13263615","name":"Finance"},{"id":"13999355","name":"zDatabase"},{"id":"13999356","name":"Workspace"},{"id":"13999554","name":"Database"},{"id":"13999560","name":"Workflows"},{"id":"14098003","name":"LaunchEngine"},{"id":"14219791","name":"Dashboards"},{"id":"14220129","name":"Documentation"},{"id":"14220141","name":"LaunchEngine"}]},"account_id":15314314}'
+  recorded_at: Mon, 21 Oct 2024 02:00:59 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_query/when_client_is_authenticated/when_valid_fields_are_requested/returns_the_body_with_ID_and_name.yml
+++ b/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_query/when_client_is_authenticated/when_valid_fields_are_requested/returns_the_body_with_ID_and_name.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"query{folders{id name}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Oct 2024 02:00:59 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Api-Version:
+      - 2024-10
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"c407e74c1a39eba6cd0242f963afb49f"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 22c99ee5-89dc-9cef-9b6b-afcc20295010
+      X-Runtime:
+      - '0.172934'
+      X-Envoy-Upstream-Service-Time:
+      - '177'
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=LUKorA2X37bfkeMhbuQn6mGwMTyL4gfX.KRq3EEHJvI-1729476059-1.0.1.1-yVH4HHvf1nXO7eruSSHQyegJex95H8W52yo5JBtnpCi8g._P1G4mrgMna8A.C6waGBRO9AI9QuIpMoKpYDoF5s9zH2zZKJ8YW89Q_zOAB2A;
+        path=/; expires=Mon, 21-Oct-24 02:30:59 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d5da8390f282b94-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"folders":[{"id":"10918734","name":"LE Development Team"},{"id":"10977318","name":"CRM"},{"id":"11061563","name":"LB"},{"id":"12772091","name":"Projects"},{"id":"12774555","name":"Meetings"},{"id":"13019652","name":"1836"},{"id":"13145433","name":"Database"},{"id":"13145448","name":"Workspace"},{"id":"13155563","name":"Job
+        Flow"},{"id":"13156741","name":"Reporting"},{"id":"13156743","name":"Other"},{"id":"13157369","name":"Reports"},{"id":"13177585","name":"Rentvine"},{"id":"13190752","name":"RentVine
+        Sync"},{"id":"13201660","name":"Documentation"},{"id":"13214161","name":"Sandbox"},{"id":"13263615","name":"Finance"},{"id":"13999355","name":"zDatabase"},{"id":"13999356","name":"Workspace"},{"id":"13999554","name":"Database"},{"id":"13999560","name":"Workflows"},{"id":"14098003","name":"LaunchEngine"},{"id":"14219791","name":"Dashboards"},{"id":"14220129","name":"Documentation"},{"id":"14220141","name":"LaunchEngine"}]},"account_id":15314314}'
+  recorded_at: Mon, 21 Oct 2024 02:00:59 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_query/when_client_is_not_authenticated/behaves_like_unauthenticated_client_request/raises_Monday_AuthorizationError_error.yml
+++ b/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_query/when_client_is_not_authenticated/behaves_like_unauthenticated_client_request/raises_Monday_AuthorizationError_error.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"query{folders{id name}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - invalid_token
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Date:
+      - Mon, 21 Oct 2024 02:00:58 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Powered-By:
+      - Express
+      Etag:
+      - W/"20-1sxs6kzKvML1MCq/a35DgifHwjk"
+      Vary:
+      - Origin, Accept-Encoding
+      X-Monday-Auth:
+      - 'true'
+      X-Monday-Region:
+      - undefined
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=KwSIO9G4jQpi7Clx2lmkeoPBNY45qhwrCj2Rd.aqcFg-1729476058-1.0.1.1-i3wdqxUiJqdg1d4jRASTS0os6da5cjKOtncUIxtW2FyvL86SDg8e2dwfw9_VUKmvQHCEHdZH50n5zeC_NJK.YR0K.OgfD5ypHGOHvpfEp7k;
+        path=/; expires=Mon, 21-Oct-24 02:30:58 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d5da835eb9669b0-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"errors":["Not Authenticated"]}'
+  recorded_at: Mon, 21 Oct 2024 02:00:58 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_update/when_client_is_authenticated/when_a_the_folder_with_the_given_folder_ID_does_not_exist/raises_Monday_Error_error.yml
+++ b/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_update/when_client_is_authenticated/when_a_the_folder_with_the_given_folder_ID_does_not_exist/raises_Monday_Error_error.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"mutation{update_folder(folder_id: 1234567, name: \"Dogs\"){id}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Oct 2024 02:01:04 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Api-Version:
+      - 2024-10
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"e58b57ec00d18d470ec177c7587cb526"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - af3a4c14-a0ed-92fa-935d-29b299cd29bf
+      X-Runtime:
+      - '0.084396'
+      X-Envoy-Upstream-Service-Time:
+      - '86'
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=qu420glk_U5TjSqNA4vcXWuV9PNZ5P_zXEDh7S5jPvU-1729476064-1.0.1.1-FSqqEZJ_Lg4ThW.Tq1UeNj7yFGGN1_7BUxKVAdiYq.DZB4j_HLsF5QMxKY1C9nY2dnrKnCejMlJDKdoTMrv5glT1Wnce3rXlZ9dq7UZI1vE;
+        path=/; expires=Mon, 21-Oct-24 02:31:04 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d5da8583db40d38-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"errors":[{"message":"The folder does not exist. Please check your
+        folder ID and try again","locations":[{"line":1,"column":10}],"path":["update_folder"],"extensions":{"code":"InvalidFolderIdException","status_code":200,"error_data":{"folder_id":1234567}}}],"error_message":"The
+        folder does not exist. Please check your folder ID and try again","error_code":"InvalidFolderIdException","error_data":{"folder_id":1234567},"status_code":200,"account_id":15314314}'
+  recorded_at: Mon, 21 Oct 2024 02:01:04 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_update/when_client_is_authenticated/when_args_are_invalid/raises_Monday_Error_error.yml
+++ b/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_update/when_client_is_authenticated/when_args_are_invalid/raises_Monday_Error_error.yml
@@ -1,0 +1,208 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"mutation{create_workspace(name: \"Test Workspace\", kind:
+        open){id name description}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Oct 2024 02:01:04 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Api-Version:
+      - 2024-10
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"316204d4a7f7dd3845fe85b036c26364"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - be83d4e7-5b49-991e-bdb5-07d8aafc8db1
+      X-Runtime:
+      - '0.271717'
+      X-Envoy-Upstream-Service-Time:
+      - '274'
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=Fb_MH0ilVPdINRpxOWnoOeQNPMhtjeUaTdlOU7Qysq4-1729476064-1.0.1.1-KzvyvAr9q4jFVggpXXwk9GLb56DNofNy0cRFvESyuTZDyNfkfUWUCcVXee.uhUl4BP2uHW5dWT3uLfV8toJ74zNz7FSJrcPPPPqxY0NGWZI;
+        path=/; expires=Mon, 21-Oct-24 02:31:04 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d5da859bb97dbae-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"create_workspace":{"id":"8529958","name":"Test Workspace","description":null}},"account_id":15314314}'
+  recorded_at: Mon, 21 Oct 2024 02:01:04 GMT
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"mutation{create_folder(workspace_id: \"8529958\", name: \"Database
+        boards\"){id name}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Oct 2024 02:01:05 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Api-Version:
+      - 2024-10
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"1d4ee1ce33032a965e7f72a35c79cab6"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - d85d24fd-5b2b-9453-950f-331647f4cf07
+      X-Runtime:
+      - '0.367989'
+      X-Envoy-Upstream-Service-Time:
+      - '371'
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=NBrA4y1AKHtfjPXHp3.dWdHR_DHjMPms93CJDztJNCY-1729476065-1.0.1.1-LPkoz.HdmT6QevsEE22feSYQA2WS7JI2SKKt5TMkQZF9MslKjwaqQxdUpkwV0H6NTJwT6Fv7otWa70tuAtNg5LbuQ.11mUMEWvGbvgnEZKk;
+        path=/; expires=Mon, 21-Oct-24 02:31:05 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d5da85c789d2b4e-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"create_folder":{"id":"15476752","name":"Database boards"}},"account_id":15314314}'
+  recorded_at: Mon, 21 Oct 2024 02:01:05 GMT
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"mutation{update_folder(folder_id: \"15476752\", name: \"Some
+        other name\", invalid_field: \"test\"){id}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Oct 2024 02:01:05 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Api-Version:
+      - 2024-10
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"76901817d5f2cd8ac064956a745a949b"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 643eff06-e5e1-9ae0-9b1e-bbd88f8542ab
+      X-Runtime:
+      - '0.055720'
+      X-Envoy-Upstream-Service-Time:
+      - '59'
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=esgoHUu1xniv9IrxKVjsEWq.wTrlw63HY1tUJDIurfI-1729476065-1.0.1.1-sA_4HgznZdBeHV_G4_aPFF_n67GLttlsl7ghZxoamcR5XYtOHCDD07zqxXOiPrsZ2qV2Us3.tTNj2SXNnCv7oxDp28lpZnD_fiRm1lgSXO4;
+        path=/; expires=Mon, 21-Oct-24 02:31:05 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d5da8600c467cf8-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"errors":[{"message":"Field ''update_folder'' doesn''t accept argument
+        ''invalid_field''","locations":[{"line":1,"column":72}],"path":["mutation","update_folder","invalid_field"],"extensions":{"code":"argumentNotAccepted","name":"update_folder","typeName":"Field","argumentName":"invalid_field"}}],"account_id":15314314}'
+  recorded_at: Mon, 21 Oct 2024 02:01:05 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_update/when_client_is_authenticated/when_args_are_valid/behaves_like_authenticated_client_request/returns_200_status.yml
+++ b/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_update/when_client_is_authenticated/when_args_are_valid/behaves_like_authenticated_client_request/returns_200_status.yml
@@ -1,0 +1,207 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"mutation{create_workspace(name: \"Test Workspace\", kind:
+        open){id name description}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Oct 2024 02:01:01 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Api-Version:
+      - 2024-10
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"5857de59312e168a37ffa2dffcf4f59a"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - bd17bf7f-b413-925d-bde5-bb28ab636854
+      X-Runtime:
+      - '0.242909'
+      X-Envoy-Upstream-Service-Time:
+      - '245'
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=RvF.LM6HSnwq02jdussPhGZ_HRYjOe_fPCPCP.r780M-1729476061-1.0.1.1-EKyaigh8SjDuje1.yd0CjOezAQxLIz786notEkbJY50vY0os_yhReCK2Un872PxZxxfwQRj4TOIYZ7uwJ3DVrMeMW9aP3DRC.k3tpjBW7IM;
+        path=/; expires=Mon, 21-Oct-24 02:31:01 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d5da847cbe91039-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"create_workspace":{"id":"8529956","name":"Test Workspace","description":null}},"account_id":15314314}'
+  recorded_at: Mon, 21 Oct 2024 02:01:01 GMT
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"mutation{create_folder(workspace_id: \"8529956\", name: \"Database
+        boards\"){id name}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Oct 2024 02:01:03 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Api-Version:
+      - 2024-10
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"461636b21f32e6a680606238c8bcef80"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 270ba37e-4ee6-9a56-a9de-ff364853c736
+      X-Runtime:
+      - '0.753153'
+      X-Envoy-Upstream-Service-Time:
+      - '1554'
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=RshI5vatrWskMB7MYO6IU8nZ4.lkJQUKyhQOJPqhDWI-1729476063-1.0.1.1-sG_zgpRsw0PSwIx3NyOStwxLfSNRssBMyIADl3_HA8d07YyBYh9CaHSot549c6.6n3w18CuFC_hT0R3zoCM275uuph4EtomLAYX0MTJ..ko;
+        path=/; expires=Mon, 21-Oct-24 02:31:03 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d5da84a6ab8cb9c-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"create_folder":{"id":"15476751","name":"Database boards"}},"account_id":15314314}'
+  recorded_at: Mon, 21 Oct 2024 02:01:03 GMT
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"mutation{update_folder(folder_id: \"15476751\", name: \"Cool
+        boards\"){id}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Oct 2024 02:01:03 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Api-Version:
+      - 2024-10
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"6ec481f8ff53293a6b6e31dc06739b4b"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 8224c358-c898-9285-a4ba-063421a726e3
+      X-Runtime:
+      - '0.297607'
+      X-Envoy-Upstream-Service-Time:
+      - '302'
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=pkefhDoXON0JMeW4LGreavsfovaq4hJR9snyl1KT7.w-1729476063-1.0.1.1-AIHFgsTvCNq3FO4UNcB3Y.LBOrbuU.s4QoNrlUxFFfB9lBMkxNeVqo6.lyuyc14p8J7f.Xr7TE3Evgth0184_b4fBldANsgNtY1npZUQEXk;
+        path=/; expires=Mon, 21-Oct-24 02:31:03 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d5da855289fdbcc-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"update_folder":{"id":"15476751"}},"account_id":15314314}'
+  recorded_at: Mon, 21 Oct 2024 02:01:03 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_update/when_client_is_authenticated/when_args_are_valid/returns_the_body_with_updated_folders_ID.yml
+++ b/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_update/when_client_is_authenticated/when_args_are_valid/returns_the_body_with_updated_folders_ID.yml
@@ -1,0 +1,207 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"mutation{create_workspace(name: \"Test Workspace\", kind:
+        open){id name description}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Oct 2024 02:01:00 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Api-Version:
+      - 2024-10
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"847cd0e6393d37526b8825fc915c9553"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - e17208fd-a978-931c-8c8b-47f839e0694a
+      X-Runtime:
+      - '0.419294'
+      X-Envoy-Upstream-Service-Time:
+      - '422'
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=uMzYCKwSQw__jRKOHhQBXGyATdCdc6VYLn.qDmksA2c-1729476060-1.0.1.1-ifOQ7Rz82pMzbTvC5NdUpE8P2QMf.qXrNmDsnyCbVWwXuJLQ_6Olna5txq0IM0W0HeUM5X1OW6hys1272lv5clqaWSyh03il1Plcs_Rcl_Y;
+        path=/; expires=Mon, 21-Oct-24 02:31:00 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d5da83e0a042b63-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"create_workspace":{"id":"8529955","name":"Test Workspace","description":null}},"account_id":15314314}'
+  recorded_at: Mon, 21 Oct 2024 02:01:00 GMT
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"mutation{create_folder(workspace_id: \"8529955\", name: \"Database
+        boards\"){id name}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Oct 2024 02:01:00 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Api-Version:
+      - 2024-10
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"5f28472da88ab72286657f8cae80cf0d"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - e0d5c31f-af7c-9285-8454-3c26702b76ce
+      X-Runtime:
+      - '0.330329'
+      X-Envoy-Upstream-Service-Time:
+      - '333'
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=vaMvlhSodaRvEUNPywSHTiHYLsJRimnOKuH3CEMQ0eE-1729476060-1.0.1.1-2xy5Aqh0dRJy4hOwiCF2VerUoUSN.5ObK9cbuhFwKOZVcQLgyb7diDPfIuLSY7gE6Sz5EHWQakBIyD8H0ZT_ERbRl2zJUJX9lOmxomt4kyc;
+        path=/; expires=Mon, 21-Oct-24 02:31:00 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d5da841fdf608fc-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"create_folder":{"id":"15476750","name":"Database boards"}},"account_id":15314314}'
+  recorded_at: Mon, 21 Oct 2024 02:01:00 GMT
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"mutation{update_folder(folder_id: \"15476750\", name: \"Cool
+        boards\"){id}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Oct 2024 02:01:01 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Api-Version:
+      - 2024-10
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"cae798350afcdc6640dd9fe84f775587"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 476fe88c-209c-907d-807f-c5325e74c27d
+      X-Runtime:
+      - '0.233264'
+      X-Envoy-Upstream-Service-Time:
+      - '236'
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=F1dm0IX.yTUxHCP1PAf78zH4jJDie2DMwZ.J_XL0ugM-1729476061-1.0.1.1-F6YSAzmXq6SUgE0N4QoqHI.nsjw.Z.KDccnfyemPW0rhIh3BVGpfVJyFLBvjNod2BwygfdUQ3.Qk4o9egXX_adZacam4NOLfEz4.rv4aXVM;
+        path=/; expires=Mon, 21-Oct-24 02:31:01 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d5da8453d1b5367-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"update_folder":{"id":"15476750"}},"account_id":15314314}'
+  recorded_at: Mon, 21 Oct 2024 02:01:01 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_update/when_client_is_not_authenticated/behaves_like_unauthenticated_client_request/raises_Monday_AuthorizationError_error.yml
+++ b/spec/fixtures/vcr_cassettes/Monday_Resources_Folder/_update/when_client_is_not_authenticated/behaves_like_unauthenticated_client_request/raises_Monday_AuthorizationError_error.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"mutation{update_folder{id}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - invalid_token
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Date:
+      - Mon, 21 Oct 2024 02:00:59 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"20-1sxs6kzKvML1MCq/a35DgifHwjk"
+      X-Powered-By:
+      - Express
+      X-Monday-Auth:
+      - 'true'
+      X-Monday-Region:
+      - undefined
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=Q06Ym.N3VKvf.AVDIzdFqiVuSw6xjZlwe26SzdLLk5I-1729476059-1.0.1.1-.aIZE_qqPnQGyNVb6kBiBxRv7PorFQcnPNhY9KYupHNB5qnB4GXXs8kdzGfSXlmCrZYkyA0FY0rJ8RA6l2JjvkpE4WFUDslFTfe2zZ8PD5U;
+        path=/; expires=Mon, 21-Oct-24 02:30:59 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d5da83d1a0a2aed-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: '{"errors":["Not Authenticated"]}'
+  recorded_at: Mon, 21 Oct 2024 02:00:59 GMT
+recorded_with: VCR 6.2.0

--- a/spec/monday/resources/folder_spec.rb
+++ b/spec/monday/resources/folder_spec.rb
@@ -1,0 +1,222 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "unauthenticated client request" do
+  it "raises Monday::AuthorizationError error" do
+    expect { response }.to raise_error(Monday::AuthorizationError)
+  end
+end
+
+RSpec.shared_examples "authenticated client request" do
+  it "returns 200 status" do
+    expect(response.status).to eq(200)
+  end
+end
+
+RSpec.describe Monday::Resources::Folder, :vcr do
+  describe ".query" do
+    subject(:response) { client.folder.query(select: select) }
+
+    context "when client is not authenticated" do
+      let(:client) { invalid_client }
+      let(:select) { %w[id name] }
+
+      it_behaves_like "unauthenticated client request"
+    end
+
+    context "when client is authenticated" do
+      let(:client) { valid_client }
+
+      context "when an invalid field is requested" do
+        let(:select) { ["invalid_field"] }
+
+        it "raises Monday::Error error" do
+          expect { response }.to raise_error(Monday::Error)
+        end
+      end
+
+      context "when valid fields are requested" do
+        let(:select) { %w[id name] }
+
+        it_behaves_like "authenticated client request"
+
+        it "returns the body with ID and name" do
+          expect(
+            response.body["data"]["folders"]
+          ).to match(array_including(hash_including("id", "name")))
+        end
+      end
+    end
+  end
+
+  describe ".create" do
+    subject(:response) { client.folder.create(args: args) }
+
+    context "when client is not authenticated" do
+      let(:client) { invalid_client }
+      let(:args) { {} }
+
+      it_behaves_like "unauthenticated client request"
+    end
+
+    context "when client is authenticated" do
+      let(:client) { valid_client }
+
+      context "when a field that doesn't exist on folders is given" do
+        let(:args) do
+          {
+            workspace_id: workspace_id,
+            name: "Database boards",
+            invalid_field: "test"
+          }
+        end
+        let!(:create_workspace) do
+          client.workspace.create(args: { name: "Test Workspace", kind: :open })
+        end
+        let(:workspace_id) { create_workspace.body["data"]["create_workspace"]["id"] }
+
+        it "raises Monday::Error error" do
+          expect { response }.to raise_error(Monday::Error)
+        end
+      end
+
+      context "when args are valid" do
+        let(:args) do
+          {
+            workspace_id: workspace_id,
+            name: "Database boards"
+          }
+        end
+        let!(:create_workspace) do
+          client.workspace.create(args: { name: "Test Workspace", kind: :open })
+        end
+        let(:workspace_id) { create_workspace.body["data"]["create_workspace"]["id"] }
+
+        it_behaves_like "authenticated client request"
+
+        it "returns the body with created folders ID and Title" do
+          expect(
+            response.body["data"]["create_folder"]
+          ).to match(hash_including("id", "name"))
+        end
+      end
+    end
+  end
+
+  describe ".update" do
+    subject(:response) { client.folder.update(args: args) }
+
+    context "when client is not authenticated" do
+      let(:client) { invalid_client }
+      let(:args) { {} }
+
+      it_behaves_like "unauthenticated client request"
+    end
+
+    context "when client is authenticated" do
+      let(:client) { valid_client }
+
+      context "when a the folder with the given folder ID does not exist" do
+        let(:args) do
+          {
+            folder_id: 1_234_567,
+            name: "Dogs"
+          }
+        end
+
+        it "raises Monday::Error error" do
+          # This throws an ActiveRecord error on the Monday API side.
+          expect { response }.to raise_error(Monday::Error)
+        end
+      end
+
+      context "when args are invalid" do
+        let(:args) do
+          {
+            folder_id: folder_id,
+            name: "Some other name",
+            invalid_field: "test"
+          }
+        end
+        let!(:create_workspace) do
+          client.workspace.create(args: { name: "Test Workspace", kind: :open })
+        end
+        let(:workspace_id) { create_workspace.body["data"]["create_workspace"]["id"] }
+        let!(:create_folder) do
+          client.folder.create(args: { workspace_id: workspace_id, name: "Database boards" })
+        end
+        let(:folder_id) { create_folder.body["data"]["create_folder"]["id"] }
+
+        it "raises Monday::Error error" do
+          expect { response }.to raise_error(Monday::Error)
+        end
+      end
+
+      context "when args are valid" do
+        let(:args) do
+          {
+            folder_id: folder_id,
+            name: "Cool boards"
+          }
+        end
+        let!(:create_workspace) do
+          client.workspace.create(args: { name: "Test Workspace", kind: :open })
+        end
+        let(:workspace_id) { create_workspace.body["data"]["create_workspace"]["id"] }
+        let!(:create_folder) do
+          client.folder.create(args: { workspace_id: workspace_id, name: "Database boards" })
+        end
+        let(:folder_id) { create_folder.body["data"]["create_folder"]["id"] }
+
+        it_behaves_like "authenticated client request"
+
+        it "returns the body with updated folders ID" do
+          expect(
+            response.body["data"]["update_folder"]
+          ).to match(hash_including("id"))
+        end
+      end
+    end
+  end
+
+  describe ".delete" do
+    subject(:response) { client.folder.delete(args: { folder_id: folder_id }) }
+
+    context "when client is not authenticated" do
+      let(:client) { invalid_client }
+      let(:folder_id) { "123" }
+
+      it_behaves_like "unauthenticated client request"
+    end
+
+    context "when client is authenticated" do
+      let(:client) { valid_client }
+
+      context "when a the folder with the given folder ID does not exist" do
+        let(:folder_id) { "invalid_folder_name" }
+
+        it "raises Monday::ResourceNotFoundError error" do
+          expect { response }.to raise_error(Monday::Error)
+        end
+      end
+
+      context "when the args are valid" do
+        let!(:create_workspace) do
+          client.workspace.create(args: { name: "Test Workspace", kind: :open })
+        end
+        let(:workspace_id) { create_workspace.body["data"]["create_workspace"]["id"] }
+        let!(:create_folder) do
+          client.folder.create(args: { workspace_id: workspace_id, name: "Database boards" })
+        end
+        let(:folder_id) { create_folder.body["data"]["create_folder"]["id"] }
+
+        it_behaves_like "authenticated client request"
+
+        it "returns the body with deleted folders ID" do
+          expect(
+            response.body["data"]["delete_folder"]
+          ).to match(hash_including("id"))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This feature adds support for workspace folders. You can Query, Create, Update, and Delete folders.

This feature does not change how other areas of the code works. However, you can now pass in a folder_id when creating a board to add that board to a folder.

This has been tested against my production Monday account.

I added spec tests that are similar to the existing specs to cover Query, Create, Update, and Delete. They were modeled after the Groups specs.

I have not updated the documentation, but I will update the docs if this gets accepted.

## Checklist:

- [X] I have performed a self-review of my own code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the project documentation.
- [X] I have added a changelog line.
