### PR TITLE
add filter parameter to column query method

### DIFF
--- a/lib/monday/resources/column.rb
+++ b/lib/monday/resources/column.rb
@@ -12,9 +12,11 @@ module Monday
       #
       # Allows filtering columns using the args option.
       # Allows customizing the values to retrieve using the select option.
+      # Allows additional filtering using the filter_params option.
       # By default, ID, title and description fields are retrieved.
-      def query(args: {}, select: DEFAULT_SELECT)
-        request_query = "query{boards#{Util.format_args(args)}{columns{#{Util.format_select(select)}}}}"
+      def query(args: {}, select: DEFAULT_SELECT, filter_params: {})
+        formatted_filter = Util.format_filter_params(filter_params)
+        request_query = "query{boards#{Util.format_args(args)}{columns#{formatted_filter}{#{Util.format_select(select)}}}}"
 
         make_request(request_query)
       end

--- a/lib/monday/util.rb
+++ b/lib/monday/util.rb
@@ -18,6 +18,13 @@ module Monday
         "(#{formatted})"
       end
 
+      def format_filter_params(params)
+        return "" if params.empty?
+
+        formatted = params.map { |key, value| "#{key}: #{format_filter_value(value)}" }.join(", ")
+        "(#{formatted})"
+      end
+
       # Converts the select values into a valid string for API.
       #
       # input: ["id", "name", { "columns": ["id"] }]
@@ -27,6 +34,17 @@ module Monday
         return format_array(value) if value.is_a?(Array)
 
         values
+      end
+
+      def format_filter_value(value)
+        case value
+        when String
+          "\"#{value}\""
+        when Array
+          "[#{value.map { |v| format_filter_value(v) }.join(", ")}]"
+        else
+          value.to_s
+        end
       end
 
       def status_code_exceptions_mapping(status_code)

--- a/spec/fixtures/vcr_cassettes/Monday_Resources_Column/_query/when_client_is_authenticated/when_valid_field_is_requested/when_we_pass_filter_params/returns_the_body_with_column_ID_title_and_description.yml
+++ b/spec/fixtures/vcr_cassettes/Monday_Resources_Column/_query/when_client_is_authenticated/when_valid_field_is_requested/when_we_pass_filter_params/returns_the_body_with_column_ID_title_and_description.yml
@@ -1,0 +1,211 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"mutation{create_board(board_name: \"Test Board\", board_kind:
+        private){id name description}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Oct 2024 14:58:14 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Api-Version:
+      - 2024-10
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"6bfde10f063c33e500589cb6219920fe"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - ede040a9-0873-9314-b62e-24678b7cd168
+      X-Runtime:
+      - '2.375796'
+      X-Envoy-Upstream-Service-Time:
+      - '2379'
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=ivAhf4PLe.XW.c1iiMAMFoNxgrUMHWibaYEzf1XYr5M-1730213894-1.0.1.1-jJFBD._n7XSSiSCC0UYE9UeGQQwYeW4MzrfBy7KD2ABEEMcprhi8N1eS9ypQEjpdgF6ROi5MwcPOs1cTIw7cbYWCt23SB3Xr3AlwEQ0QKtU;
+        path=/; expires=Tue, 29-Oct-24 15:28:14 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8da405b68d6f15b9-FOR
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"create_board":{"id":"7734869363","name":"Test Board","description":null}},"account_id":20813174}'
+  recorded_at: Tue, 29 Oct 2024 14:58:13 GMT
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"mutation{create_column(board_id: \"7734869363\", title: \"Test
+        Column\", column_type: text){id title description}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Oct 2024 14:58:14 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Api-Version:
+      - 2024-10
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"de912cd11cc8557ccfc6a0b4bfe31355"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 78d35c26-b1bf-9eca-9a99-40e9170ceec5
+      X-Runtime:
+      - '0.378868'
+      X-Envoy-Upstream-Service-Time:
+      - '380'
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=kxXm0lnv.vdJdBtlDJVnvzhsYZnR6RXP3KXiWPPJ3WQ-1730213894-1.0.1.1-cEKhY7ZUr_EXpNoXowaKBnCdiTCr82pm4ZEfjEWuFA6UMmvTsXoNPPk8rQtdevFdZ7NERr3oUtegYvIIlYumoApxV0ruHDftgb_hgBVpWu0;
+        path=/; expires=Tue, 29-Oct-24 15:28:14 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8da405c68b4715b9-FOR
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"create_column":{"id":"test_column__1","title":"Test Column","description":null}},"account_id":20813174}'
+  recorded_at: Tue, 29 Oct 2024 14:58:14 GMT
+- request:
+    method: post
+    uri: https://api.monday.com/v2
+    body:
+      encoding: UTF-8
+      string: '{"query":"query{boards{columns(types: [date, status]){id title description}}}"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Oct 2024 14:58:15 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Api-Version:
+      - 2024-10
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"a8d5a1c1dc3e03fa1943e909e89e4677"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 3b63a197-bb25-9e8c-868f-87a2ccda6450
+      X-Runtime:
+      - '1.137710'
+      X-Envoy-Upstream-Service-Time:
+      - '1141'
+      Content-Security-Policy:
+      - ";"
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors https://*.monday.com; script-src 'self'; worker-src 'self';
+        connect-src 'self'; report-uri https://o916138.ingest.us.sentry.io/api/4507803872198656/security/?sentry_key=8e1fb7e952d4abfd146752c94791f51a&sentry_environment=production;
+      X-Monday-Rgn:
+      - use1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=l3owYBNq.K0.AFdQSs11LlwTkYLcD1w9xwU781Ai8Ic-1730213895-1.0.1.1-dlRvCP9Y98c292SkRIyH40bAMOYHzVeM0M0YCcVO0r2lYJqEb9NmxBzRo9MbHDumYZPttLQykO4dMXkW.lKFd3lpM9wC2WSDmM608PXtm6E;
+        path=/; expires=Tue, 29-Oct-24 15:28:15 GMT; domain=.monday.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8da405c9f81815a9-FOR
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"boards":[{"columns":[{"id":"status","title":"Name","description":null},{"id":"status","title":"Test
+        Column","description":null}]},{"columns":[{"id":"name","title":"Name","description":null},{"id":"test_column__1","title":"Test
+        Column","description":null}]},{"columns":[{"id":"name","title":"Name","description":null},{"id":"test_column__1","title":"Test
+        Column","description":null}]},{"columns":[{"id":"name","title":"Name","description":null}]},{"columns":[{"id":"name","title":"Name","description":null}]},{"columns":[{"id":"name","title":"Name","description":null}]},{"columns":[{"id":"name","title":"Name","description":null}]},{"columns":[{"id":"name","title":"Name","description":null}]},{"columns":[{"id":"name","title":"Name","description":null}]},{"columns":[{"id":"name","title":"Name","description":null}]},{"columns":[{"id":"name","title":"Name","description":null}]},{"columns":[{"id":"name","title":"Name","description":null}]},{"columns":[{"id":"name","title":"Name","description":null}]},{"columns":[{"id":"name","title":"Name","description":null}]},{"columns":[{"id":"name","title":"Name","description":null}]},{"columns":[{"id":"name","title":"Name","description":null}]},{"columns":[{"id":"name","title":"Name","description":null}]},{"columns":[{"id":"name","title":"Name","description":null}]},{"columns":[{"id":"name","title":"Name","description":null}]},{"columns":[{"id":"name","title":"Name","description":null}]},{"columns":[{"id":"name","title":"Name","description":null}]},{"columns":[{"id":"name","title":"Name","description":null}]},{"columns":[{"id":"name","title":"Name","description":null},{"id":"status__1","title":"Status","description":"Status
+        Column"}]},{"columns":[{"id":"name","title":"Name","description":null}]},{"columns":[{"id":"name","title":"Name","description":null},{"id":"status__1","title":"Status","description":"Status
+        Column"}]}]},"account_id":24308083}'
+  recorded_at: Tue, 29 Oct 2024 14:58:15 GMT
+recorded_with: VCR 6.3.1

--- a/spec/monday/resources/column_spec.rb
+++ b/spec/monday/resources/column_spec.rb
@@ -59,6 +59,18 @@ RSpec.describe Monday::Resources::Column, :vcr do
             response.body["data"]["boards"].first["columns"]
           ).to match(array_including(hash_including("id", "title", "description")))
         end
+
+        context "when we pass filter_params" do
+          subject(:response) { client.column.query(select: select, filter_params: filter_params) }
+
+          let(:filter_params) { { types: %i[date status] } }
+
+          it "returns the body with column ID, title and description" do
+            expect(
+              response.body["data"]["boards"].first["columns"]
+            ).to match(array_including(hash_including("id", "title", "description")))
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## Description

Please, include a summary of what the PR is for:
- **What is the problem it is solving?**
  The current implementation of the `query` method does not support additional filter parameters for columns, which limits the flexibility of the API calls.
- **What is the context of these changes?**
  This PR adds support for additional filter parameters in the `query` method, allowing users to pass custom filters that will be included in the API request.
- **What is the impact of this PR?**
  This change enhances the functionality of the `query` method by allowing more granular filtering of columns, making the API more versatile and powerful.

## How has this been tested?

Please, describe the tests that you ran to verify your changes.
Call Column query method passing filter_parameters like this: 

`$ client.column.query(filter_params: {types: [:status]}) `
`$ client.column.query(filter_params: {types: [:date]}) `
`$ client.column.query(filter_params: {types: [:date, :status]}) `
`$ client.column.query `

## Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have updated the project documentation.