### PR TITLE
support array values in formatted-args-value

### DIFF
--- a/lib/monday/util.rb
+++ b/lib/monday/util.rb
@@ -80,6 +80,7 @@ module Monday
         return value if value.is_a?(Symbol)
         return value.to_json.to_json if value.is_a?(Hash)
         return value if integer?(value)
+        return value if value.is_a?(Array)
 
         "\"#{value}\""
       end


### PR DESCRIPTION
## Description

What is the problem it is solving?
The current implementation of some queries in the gem expects an argument to be passed as an array (e.g., workspace_ids in the boards query). However, when this argument is passed through the gem, it is being incorrectly formatted as a string instead of an array. This leads to mismatched data types and potential issues when interacting with the API.

What is the context of these changes?
The issue was identified in queries that rely on array arguments, particularly in the handling of workspace IDs. To ensure proper functionality and alignment with the expected API behavior, the argument handling logic in the gem needed to be adjusted to correctly pass arrays as arrays.

What is the impact of this PR?
This PR resolves the formatting issue, ensuring that array arguments are correctly passed as arrays instead of strings. This fix improves the gem’s compatibility with the API, prevents potential runtime errors, and enhances the overall reliability of query executions involving array arguments.

```ruby
response = client.board.query(args: { workspace_ids: [12345], limit: 1000 }, select: %w[id name description type])
```
Currently, the request query is constructed as follows:
`query{boards(workspace_ids: "[12345]", limit: 1000){id name description type}}`

However, the correct format should be:
`query{boards(workspace_ids: [12345], limit: 1000){id name description type}}`
